### PR TITLE
Add missing <name> to pom.xml

### DIFF
--- a/dotnet/pom.xml
+++ b/dotnet/pom.xml
@@ -28,6 +28,7 @@
     </parent>
 
     <artifactId>adaptersdk-schema-dotnet</artifactId>
+    <name>adaptersdk-schema-dotnet</name>
     <packaging>pom</packaging>
 
     <properties>

--- a/java/adaptersdk-schema-java-generator/pom.xml
+++ b/java/adaptersdk-schema-java-generator/pom.xml
@@ -28,6 +28,7 @@
     </parent>
 
     <artifactId>adaptersdk-schema-java-generator</artifactId>
+    <name>adaptersdk-schema-java-generator</name>
 
     <dependencies>
         <dependency>

--- a/java/adaptersdk-schema-java-interfaces/pom.xml
+++ b/java/adaptersdk-schema-java-interfaces/pom.xml
@@ -28,6 +28,7 @@
     </parent>
 
     <artifactId>adaptersdk-schema-java-interfaces</artifactId>
+    <name>adaptersdk-schema-java-interfaces</name>
 
     <dependencies>
         <dependency>

--- a/java/adaptersdk-schema-java-jsonbuilder-jackson/pom.xml
+++ b/java/adaptersdk-schema-java-jsonbuilder-jackson/pom.xml
@@ -28,6 +28,7 @@
     </parent>
 
     <artifactId>adaptersdk-schema-java-jsonbuilder-jackson</artifactId>
+    <name>adaptersdk-schema-java-jsonbuilder-jackson</name>
 
     <dependencies>
         <dependency>

--- a/java/adaptersdk-schema-java-lib/pom.xml
+++ b/java/adaptersdk-schema-java-lib/pom.xml
@@ -28,6 +28,7 @@
     </parent>
 
     <artifactId>adaptersdk-schema-java-lib</artifactId>
+    <name>adaptersdk-schema-java-lib</name>
 
     <dependencies>
         <dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -28,6 +28,7 @@
     </parent>
 
     <artifactId>adaptersdk-schema-java</artifactId>
+    <name>adaptersdk-schema-java</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
 
     <groupId>io.github.fileanalysissuite.adaptersdk.schema</groupId>
     <artifactId>adaptersdk-schema-aggregator</artifactId>
+    <name>adaptersdk-schema-aggregator</name>
     <version>1.4.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 


### PR DESCRIPTION
This PR adds missing <name> tags to pom.xml files using their corresponding <artifactId> values, ensuring they're not added inside <parent> blocks.

https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=1029210