### PR TITLE
US1053017: Added SECURITY_ATTRIBUTES field

### DIFF
--- a/dotnet/pom.xml
+++ b/dotnet/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.github.fileanalysissuite.adaptersdk.schema</groupId>
         <artifactId>adaptersdk-schema-aggregator</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>adaptersdk-schema-dotnet</artifactId>

--- a/dotnet/src/MicroFocus.FAS.AdapterSdkSchema/SchemaObjectBuilders/StringDictionarySchemaObjectBuilderImpl.cs
+++ b/dotnet/src/MicroFocus.FAS.AdapterSdkSchema/SchemaObjectBuilders/StringDictionarySchemaObjectBuilderImpl.cs
@@ -193,7 +193,7 @@ namespace MicroFocus.FAS.AdapterSdkSchema.SchemaObjectBuilders
         {
             string nextLevelPrefix = (field == null)
                 ? _prefix + "0_"
-                : _prefix + field.FieldName + "_0_";
+                : _prefix + field.FieldName + (field.IsMultivalue ? "_0_" : "__");
 
             director.Invoke(new StringDictionarySchemaObjectBuilderImpl(_metadata, _jsonStringBuilder, nextLevelPrefix));
         }

--- a/dotnet/tests/MicroFocus.FAS.AdapterSdkSchema.Tests/AdapterSdkSchemaObjectBuilderTest.cs
+++ b/dotnet/tests/MicroFocus.FAS.AdapterSdkSchema.Tests/AdapterSdkSchemaObjectBuilderTest.cs
@@ -105,6 +105,14 @@ namespace MicroFocus.FAS.AdapterSdkSchema.Tests
                 }
             );
 
+            // Single-valued Nested object, Json encoded
+            documentBuilder.SetSecurityAttributes(
+                builder =>
+                {
+                    builder.SetAllowedGroups("group1", "group2");
+                }
+            );
+
             // multi-values Nested object, single-dimension - flattened
             //Setting multiple values for single-dimension multi-valued Nested object
             documentBuilder.SetMetadataFiles(
@@ -164,6 +172,7 @@ namespace MicroFocus.FAS.AdapterSdkSchema.Tests
             Assert.True(document.ContainsKey("TABLE_METADATA"));
             Assert.True(document.ContainsKey("ACCOUNTS"));
             Assert.True(document.ContainsKey("COLUMNS"));
+            Assert.True(document.ContainsKey("SECURITY_ATTRIBUTES__ALLOWED_GROUPS"));
             Assert.True(document.ContainsKey("METADATA_FILES_0_CONTENT"));
             Assert.True(document.ContainsKey("METADATA_FILES_1_EXTENSION"));
             Assert.True(document.ContainsKey("OCR_0_0_CONFIDENCE"));

--- a/java/adaptersdk-schema-java-generator/pom.xml
+++ b/java/adaptersdk-schema-java-generator/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.github.fileanalysissuite.adaptersdk.schema</groupId>
         <artifactId>adaptersdk-schema-java</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>adaptersdk-schema-java-generator</artifactId>

--- a/java/adaptersdk-schema-java-interfaces/pom.xml
+++ b/java/adaptersdk-schema-java-interfaces/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.github.fileanalysissuite.adaptersdk.schema</groupId>
         <artifactId>adaptersdk-schema-java</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>adaptersdk-schema-java-interfaces</artifactId>

--- a/java/adaptersdk-schema-java-jsonbuilder-jackson/pom.xml
+++ b/java/adaptersdk-schema-java-jsonbuilder-jackson/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.github.fileanalysissuite.adaptersdk.schema</groupId>
         <artifactId>adaptersdk-schema-java</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>adaptersdk-schema-java-jsonbuilder-jackson</artifactId>

--- a/java/adaptersdk-schema-java-lib/pom.xml
+++ b/java/adaptersdk-schema-java-lib/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.github.fileanalysissuite.adaptersdk.schema</groupId>
         <artifactId>adaptersdk-schema-java</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>adaptersdk-schema-java-lib</artifactId>

--- a/java/adaptersdk-schema-java-lib/src/main/java/io/github/fileanalysissuite/adaptersdk/schema/schemaobjectbuilders/StringMapSchemaObjectBuilderImpl.java
+++ b/java/adaptersdk-schema-java-lib/src/main/java/io/github/fileanalysissuite/adaptersdk/schema/schemaobjectbuilders/StringMapSchemaObjectBuilderImpl.java
@@ -261,7 +261,7 @@ final class StringMapSchemaObjectBuilderImpl implements SchemaObjectBuilder
     {
         final String nextLevelPrefix = (field == null)
             ? prefix + "0_"
-            : prefix + field.getFieldName() + "_0_";
+            : prefix + field.getFieldName() + (field.isMultivalue() ? "_0_" : "__");
 
         director.accept(new StringMapSchemaObjectBuilderImpl(metadata, jsonStringBuilder, nextLevelPrefix));
     }

--- a/java/adaptersdk-schema-java-lib/src/test/java/io/github/fileanalysissuite/adaptersdk/schema/AdapterSdkSchemaObjectBuilderTest.java
+++ b/java/adaptersdk-schema-java-lib/src/test/java/io/github/fileanalysissuite/adaptersdk/schema/AdapterSdkSchemaObjectBuilderTest.java
@@ -52,7 +52,7 @@ public final class AdapterSdkSchemaObjectBuilderTest
         // Multi-valued string
         documentBuilder.setAddressTo("person1@gmail.com", "person2@there.com");
 
-         // Single-valued Nested object, Json encoded
+        // Single-valued Nested object, Json encoded
         documentBuilder.setTableMetadata(
                 builder -> {
                     builder.setIsShuffled(false);
@@ -104,6 +104,13 @@ public final class AdapterSdkSchemaObjectBuilderTest
                     }
                 ));
             })
+        );
+
+        // Single-valued Nested object, flattened
+        documentBuilder.setSecurityAttributes(
+            builder -> {
+                builder.setAllowedGroups("group1", "group2");
+            }
         );
 
         // multi-values Nested object, single-dimension - flattened
@@ -165,6 +172,7 @@ public final class AdapterSdkSchemaObjectBuilderTest
         assertTrue(document.containsKey("TABLE_METADATA"));
         assertTrue(document.containsKey("ACCOUNTS"));
         assertTrue(document.containsKey("COLUMNS"));
+        assertTrue(document.containsKey("SECURITY_ATTRIBUTES__ALLOWED_GROUPS"));
         assertTrue(document.containsKey("METADATA_FILES_0_CONTENT"));
         assertTrue(document.containsKey("METADATA_FILES_1_EXTENSION"));
         assertTrue(document.containsKey("OCR_0_0_CONFIDENCE"));

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.github.fileanalysissuite.adaptersdk.schema</groupId>
         <artifactId>adaptersdk-schema-aggregator</artifactId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>adaptersdk-schema-java</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <groupId>io.github.fileanalysissuite.adaptersdk.schema</groupId>
     <artifactId>adaptersdk-schema-aggregator</artifactId>
     <name>adaptersdk-schema-aggregator</name>
-    <version>1.4.2-SNAPSHOT</version>
+    <version>1.5.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <description>FAS Custom Adapter SDK Schema Libraries</description>
@@ -163,12 +163,12 @@
             <dependency>
                 <groupId>io.github.fileanalysissuite.adaptersdk.schema</groupId>
                 <artifactId>adaptersdk-schema-java-interfaces</artifactId>
-                <version>1.4.2-SNAPSHOT</version>
+                <version>1.5.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.github.fileanalysissuite.adaptersdk.schema</groupId>
                 <artifactId>adaptersdk-schema-java-jsonbuilder-jackson</artifactId>
-                <version>1.4.2-SNAPSHOT</version>
+                <version>1.5.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apiguardian</groupId>

--- a/release-notes-1.5.0.md
+++ b/release-notes-1.5.0.md
@@ -1,8 +1,8 @@
-!not-ready-for-release!
-
 #### Version Number
 ${version-number}
 
 #### New Features
+- **US1053017:** Added single-value object field support
 
 #### Known Issues
+- None

--- a/schemaDefinition.json.yaml
+++ b/schemaDefinition.json.yaml
@@ -116,6 +116,11 @@
                 "type": "FULLTEXT"
             }
         },
+        "security_attributes": {
+            "ALLOWED_GROUPS": {
+                "type": "STRING[]"
+            }
+        },
         "table_metadata": {
             "IS_SHUFFLED": {
                 "mandatory": true,
@@ -356,6 +361,10 @@
         },
         "SCAN_REFERENCE": {
             "type": "STRING"
+        },
+        "SECURITY_ATTRIBUTES": {
+            "objectEncoding": "flattened",
+            "type": "security_attributes"
         },
         "SOURCE_REFERENCE": {
             "type": "STRING"


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=1053017

Also updated the code to remove the numeric separator for single-value object fields.